### PR TITLE
Variable self ref

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,7 @@ as
 self + other
     Docstring
 
+It also works when using autodoc on a class that implements these methods.
 
 After installing this module, add the following to your `conf.py` to enable it
 
@@ -37,6 +38,25 @@ After installing this module, add the following to your `conf.py` to enable it
         ...  # your other extensions
         'sphinxcontrib.prettyspecialmethods',
     ]
+
+Changing "self"
+---------------
+
+If a `meta info field`_ named :code:`self-param` is included in the docstring, its
+value will be used in place of "self" in the output:
+
+.. _meta info field: https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#info-field-lists
+
+.. code-block:: rst
+
+    .. method:: __add__(other)
+        Docstring
+        :meta self-param: obj
+
+renders to
+
+obj + other
+    Docstring
 
 
 Links

--- a/sphinxcontrib/prettyspecialmethods.py
+++ b/sphinxcontrib/prettyspecialmethods.py
@@ -10,12 +10,13 @@
 
 import pbr.version
 import sphinx.addnodes as SphinxNodes
-from docutils.nodes import Text, emphasis, inline
 from sphinx.transforms import SphinxTransform
+from docutils.nodes import Text, emphasis, field, field_name, field_body, inline, pending
 
 if False:
     # For type annotations
     from typing import Any, Dict  # noqa
+    from docutils.nodes import Node  # noqa
     from sphinx.application import Sphinx  # noqa
 
 __version__ = pbr.version.VersionInfo(
@@ -186,12 +187,51 @@ SPECIAL_METHODS = {
 }
 
 
+class PendingSelfParamName(pending):
+    def __init__(self, name):
+        # type: (str) -> None
+        super().__init__(
+            transform=PrettifySpecialMethods,
+            details={'self_param': name},
+        )
+
+    @property
+    def name(self):
+        # type: () -> str
+        return self.details['self_param']
+
+
+def is_meta_self_param_info_field(node):
+    # type: (Node) -> bool
+    if not isinstance(node, field):
+        return False
+
+    name = node.next_node(field_name).astext()
+    return name == 'meta self-param'
+
+
+def convert_meta_self_param(app, domain, objtype, contentnode):
+    # type: (Sphinx, str, str, Node) -> None
+    if not domain == 'py' or 'method' not in objtype:
+        return
+
+    # Note: Using next_node means we only find the first instance
+    # of selfparam. Additional selfparam fields are ignored and eventually
+    # deleted by the Python domain's meta filter.
+    selfparam_field = contentnode.next_node(is_meta_self_param_info_field)
+
+    if selfparam_field:
+        selfparam: str = selfparam_field.next_node(field_body).astext()
+        contentnode.append(PendingSelfParamName(selfparam))
+        selfparam_field.replace_self(())
+
+
 class PrettifySpecialMethods(SphinxTransform):
     default_priority = 800
 
     def apply(self):
         methods = (
-            sig for sig in self.document.traverse(SphinxNodes.desc_signature)
+            sig.parent for sig in self.document.traverse(SphinxNodes.desc_signature)
             if 'class' in sig
         )
 
@@ -200,10 +240,21 @@ class PrettifySpecialMethods(SphinxTransform):
             method_name = name_node.astext()
 
             if method_name in SPECIAL_METHODS:
+                # Determine name to use for self in new specification
+                # using first child occurence
+                pending_self_param = ref.next_node(PendingSelfParamName)
+                self_param = pending_self_param.name if pending_self_param else 'self'
+
                 parameters_node = ref.next_node(SphinxNodes.desc_parameterlist)
 
-                name_node.replace_self(SPECIAL_METHODS[method_name](name_node, parameters_node, 'self'))
+                new_sig = SPECIAL_METHODS[method_name](name_node, parameters_node, self_param)
+
+                name_node.replace_self(new_sig)
                 parameters_node.replace_self(())
+
+        # Remove ALL occurrences of PendingSelfParamName
+        for p in self.document.traverse(PendingSelfParamName):
+            p.replace_self(())
 
 
 def show_special_methods(app, what, name, obj, skip, options):
@@ -214,6 +265,7 @@ def show_special_methods(app, what, name, obj, skip, options):
 def setup(app):
     # type: (Sphinx) -> Dict[str, Any]
     app.add_transform(PrettifySpecialMethods)
+    app.connect('object-description-transform', convert_meta_self_param, priority=450)
     app.setup_extension('sphinx.ext.autodoc')
     app.connect('autodoc-skip-member', show_special_methods)
     return {'version': __version__, 'parallel_read_safe': True}

--- a/tests/test-autodoc-self-param/conf.py
+++ b/tests/test-autodoc-self-param/conf.py
@@ -1,0 +1,23 @@
+import sys
+import os
+
+
+doc_module_path = os.path.dirname(__file__)
+if doc_module_path not in sys.path:
+    sys.path.append(doc_module_path)
+
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinxcontrib.prettyspecialmethods',
+]
+
+
+# The suffix of source filenames.
+source_suffix = '.rst'
+
+
+autodoc_default_options = {
+    'member-order': 'bysource',
+    'exclude-members': '__weakref__,__dict__,__module__',
+}

--- a/tests/test-autodoc-self-param/index.rst
+++ b/tests/test-autodoc-self-param/index.rst
@@ -1,0 +1,4 @@
+.. automodule:: test_autodoc_self_param_module
+   :members:
+   :special-members:
+   :undoc-members:

--- a/tests/test-autodoc-self-param/test_autodoc_self_param_module.py
+++ b/tests/test-autodoc-self-param/test_autodoc_self_param_module.py
@@ -1,0 +1,225 @@
+class MethodHolder:
+    # misc (alphabetical)
+    def __await__(self):
+        """:meta self-param: obj"""
+        pass
+
+    def __call__(self, *args, **kwargs):
+        """:meta self-param: obj"""
+        pass
+
+    def __dir__(self):
+        """:meta self-param: obj"""
+        pass
+
+    def __format__(self, fmt):
+        """:meta self-param: obj"""
+        pass
+
+    def __hash__(self):
+        """:meta self-param: obj"""
+        pass
+
+    def __repr__(self):
+        """:meta self-param: obj"""
+        pass
+
+    def __sizeof__(self):
+        """:meta self-param: obj"""
+        pass
+
+    # type coercion
+
+    def __str__(self):
+        """:meta self-param: obj"""
+        pass
+
+    def __bytes__(self):
+        """:meta self-param: obj"""
+        pass
+
+    def __bool__(self):
+        """:meta self-param: obj"""
+        pass
+
+    def __int__(self):
+        """:meta self-param: obj"""
+        pass
+
+    def __float__(self):
+        """:meta self-param: obj"""
+        pass
+
+    def __complex__(self):
+        """:meta self-param: obj"""
+        pass
+
+    def __index__(self):
+        """:meta self-param: obj"""
+        pass
+
+    # attribute access
+
+    def __getattr__(self, attr):
+        """:meta self-param: obj"""
+        pass
+
+    def __setattr__(self, attr, value):
+        """:meta self-param: obj"""
+        pass
+
+    def __delattr__(self, attr):
+        """:meta self-param: obj"""
+        pass
+
+    # sequence methods
+
+    def __contains__(self, value):
+        """:meta self-param: obj"""
+        pass
+
+    def __getitem__(self, item):
+        """:meta self-param: obj"""
+        pass
+
+    def __setitem__(self, item, value):
+        """:meta self-param: obj"""
+        pass
+
+    def __delitem__(self, item):
+        """:meta self-param: obj"""
+        pass
+
+    def __iter__(self):
+        """:meta self-param: obj"""
+        pass
+
+    def __len__(self):
+        """:meta self-param: obj"""
+        pass
+
+    def __length_hint__(self):
+        """:meta self-param: obj"""
+        pass
+
+    def __reversed__(self):
+        """:meta self-param: obj"""
+        pass
+
+    # unary operators (alphabetical)
+
+    def __invert__(self):
+        """:meta self-param: obj"""
+        pass
+
+    def __neg__(self):
+        """:meta self-param: obj"""
+        pass
+
+    def __pos__(self):
+        """:meta self-param: obj"""
+        pass
+
+    # binary operators (alphabetical)
+
+    def __add__(self, other):
+        """:meta self-param: obj"""
+        pass
+
+    def __and__(self, other):
+        """:meta self-param: obj"""
+        pass
+
+    def __divmod__(self, other):
+        """:meta self-param: obj"""
+        pass
+
+    def __eq__(self, other):
+        """:meta self-param: obj"""
+        pass
+
+    def __floordiv__(self, other):
+        """:meta self-param: obj"""
+        pass
+
+    def __ge__(self, other):
+        """:meta self-param: obj"""
+        pass
+
+    def __gt__(self, other):
+        """:meta self-param: obj"""
+        pass
+
+    def __le__(self, other):
+        """:meta self-param: obj"""
+        pass
+
+    def __lshift__(self, other):
+        """:meta self-param: obj"""
+        pass
+
+    def __lt__(self, other):
+        """:meta self-param: obj"""
+        pass
+
+    def __matmul__(self, other):
+        """:meta self-param: obj"""
+        pass
+
+    def __mod__(self, other):
+        """:meta self-param: obj"""
+        pass
+
+    def __mul__(self, other):
+        """:meta self-param: obj"""
+        pass
+
+    def __ne__(self, other):
+        """:meta self-param: obj"""
+        pass
+
+    def __or__(self, other):
+        """:meta self-param: obj"""
+        pass
+
+    def __pow__(self, other):
+        """:meta self-param: obj"""
+        pass
+
+    def __rshift__(self, other):
+        """:meta self-param: obj"""
+        pass
+
+    def __sub__(self, other):
+        """:meta self-param: obj"""
+        pass
+
+    def __truediv__(self, other):
+        """:meta self-param: obj"""
+        pass
+
+    def __xor__(self, other):
+        """:meta self-param: obj"""
+        pass
+
+    # other math
+
+    def __abs__(self):
+        """:meta self-param: obj"""
+        pass
+
+    def __ceil__(self):
+        """:meta self-param: obj"""
+        pass
+
+    def __floor__(self):
+        """:meta self-param: obj"""
+        pass
+
+    def __round__(self, n):
+        """:meta self-param: obj"""
+        pass
+
+    def __trunc__(self):
+        """:meta self-param: obj"""
+        pass

--- a/tests/test-autodoc/conf.py
+++ b/tests/test-autodoc/conf.py
@@ -1,0 +1,23 @@
+import sys
+import os
+
+
+doc_module_path = os.path.dirname(__file__)
+if doc_module_path not in sys.path:
+    sys.path.append(doc_module_path)
+
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinxcontrib.prettyspecialmethods',
+]
+
+
+# The suffix of source filenames.
+source_suffix = '.rst'
+
+
+autodoc_default_options = {
+    'member-order': 'bysource',
+    'exclude-members': '__weakref__,__dict__,__module__',
+}

--- a/tests/test-autodoc/index.rst
+++ b/tests/test-autodoc/index.rst
@@ -1,0 +1,4 @@
+.. automodule:: test_autodoc_module
+   :members:
+   :special-members:
+   :undoc-members:

--- a/tests/test-autodoc/test_autodoc_module.py
+++ b/tests/test-autodoc/test_autodoc_module.py
@@ -1,0 +1,228 @@
+# Explicit empty docstrings prevent some kind of automatic or inherited
+# docstring for certain methods.
+
+class MethodHolder:
+    # misc (alphabetical)
+    def __await__(self):
+        """"""
+        pass
+
+    def __call__(self, *args, **kwargs):
+        """"""
+        pass
+
+    def __dir__(self):
+        """"""
+        pass
+
+    def __format__(self, fmt):
+        """"""
+        pass
+
+    def __hash__(self):
+        """"""
+        pass
+
+    def __repr__(self):
+        """"""
+        pass
+
+    def __sizeof__(self):
+        """"""
+        pass
+
+    # type coercion
+
+    def __str__(self):
+        """"""
+        pass
+
+    def __bytes__(self):
+        """"""
+        pass
+
+    def __bool__(self):
+        """"""
+        pass
+
+    def __int__(self):
+        """"""
+        pass
+
+    def __float__(self):
+        """"""
+        pass
+
+    def __complex__(self):
+        """"""
+        pass
+
+    def __index__(self):
+        """"""
+        pass
+
+    # attribute access
+
+    def __getattr__(self, attr):
+        """"""
+        pass
+
+    def __setattr__(self, attr, value):
+        """"""
+        pass
+
+    def __delattr__(self, attr):
+        """"""
+        pass
+
+    # sequence methods
+
+    def __contains__(self, value):
+        """"""
+        pass
+
+    def __getitem__(self, item):
+        """"""
+        pass
+
+    def __setitem__(self, item, value):
+        """"""
+        pass
+
+    def __delitem__(self, item):
+        """"""
+        pass
+
+    def __iter__(self):
+        """"""
+        pass
+
+    def __len__(self):
+        """"""
+        pass
+
+    def __length_hint__(self):
+        """"""
+        pass
+
+    def __reversed__(self):
+        """"""
+        pass
+
+    # unary operators (alphabetical)
+
+    def __invert__(self):
+        """"""
+        pass
+
+    def __neg__(self):
+        """"""
+        pass
+
+    def __pos__(self):
+        """"""
+        pass
+
+    # binary operators (alphabetical)
+
+    def __add__(self, other):
+        """"""
+        pass
+
+    def __and__(self, other):
+        """"""
+        pass
+
+    def __divmod__(self, other):
+        """"""
+        pass
+
+    def __eq__(self, other):
+        """"""
+        pass
+
+    def __floordiv__(self, other):
+        """"""
+        pass
+
+    def __ge__(self, other):
+        """"""
+        pass
+
+    def __gt__(self, other):
+        """"""
+        pass
+
+    def __le__(self, other):
+        """"""
+        pass
+
+    def __lshift__(self, other):
+        """"""
+        pass
+
+    def __lt__(self, other):
+        """"""
+        pass
+
+    def __matmul__(self, other):
+        """"""
+        pass
+
+    def __mod__(self, other):
+        """"""
+        pass
+
+    def __mul__(self, other):
+        """"""
+        pass
+
+    def __ne__(self, other):
+        """"""
+        pass
+
+    def __or__(self, other):
+        """"""
+        pass
+
+    def __pow__(self, other):
+        """"""
+        pass
+
+    def __rshift__(self, other):
+        """"""
+        pass
+
+    def __sub__(self, other):
+        """"""
+        pass
+
+    def __truediv__(self, other):
+        """"""
+        pass
+
+    def __xor__(self, other):
+        """"""
+        pass
+
+    # other math
+
+    def __abs__(self):
+        """"""
+        pass
+
+    def __ceil__(self):
+        """"""
+        pass
+
+    def __floor__(self):
+        """"""
+        pass
+
+    def __round__(self, n):
+        """"""
+        pass
+
+    def __trunc__(self):
+        """"""
+        pass

--- a/tests/test-simple-self-param/conf.py
+++ b/tests/test-simple-self-param/conf.py
@@ -1,0 +1,4 @@
+extensions = ['sphinxcontrib.prettyspecialmethods']
+
+# The suffix of source filenames.
+source_suffix = '.rst'

--- a/tests/test-simple-self-param/index.rst
+++ b/tests/test-simple-self-param/index.rst
@@ -1,0 +1,225 @@
+# misc (alphabetical)
+
+.. py:method:: __await__()
+
+   :meta self-param: obj
+
+.. py:method:: __call__(*args, **kwargs)
+
+   :meta self-param: obj
+
+.. py:method:: __dir__()
+
+   :meta self-param: obj
+
+.. py:method:: __format__(fmt)
+
+   :meta self-param: obj
+
+.. py:method:: __hash__()
+
+   :meta self-param: obj
+
+.. py:method:: __repr__()
+
+   :meta self-param: obj
+
+.. py:method:: __sizeof__()
+
+   :meta self-param: obj
+
+# type coercion
+
+.. py:method:: __str__()
+
+   :meta self-param: obj
+
+.. py:method:: __bytes__()
+
+   :meta self-param: obj
+
+.. py:method:: __bool__()
+
+   :meta self-param: obj
+
+.. py:method:: __int__()
+
+   :meta self-param: obj
+
+.. py:method:: __float__()
+
+   :meta self-param: obj
+
+.. py:method:: __complex__()
+
+   :meta self-param: obj
+
+.. py:method:: __index__()
+
+   :meta self-param: obj
+
+# attribute access
+
+.. py:method:: __getattr__(attr)
+
+   :meta self-param: obj
+
+.. py:method:: __setattr__(attr, value)
+
+   :meta self-param: obj
+
+.. py:method:: __delattr__(attr)
+
+   :meta self-param: obj
+
+# sequence methods
+
+.. py:method:: __contains__(value)
+
+   :meta self-param: obj
+
+.. py:method:: __getitem__(item)
+
+   :meta self-param: obj
+
+.. py:method:: __setitem__(item, value)
+
+   :meta self-param: obj
+
+.. py:method:: __delitem__(item)
+
+   :meta self-param: obj
+
+.. py:method:: __iter__()
+
+   :meta self-param: obj
+
+.. py:method:: __len__()
+
+   :meta self-param: obj
+
+.. py:method:: __length_hint__()
+
+   :meta self-param: obj
+
+.. py:method:: __reversed__()
+
+   :meta self-param: obj
+
+# unary operators (alphabetical)
+
+.. py:method:: __invert__()
+
+   :meta self-param: obj
+
+.. py:method:: __neg__()
+
+   :meta self-param: obj
+
+.. py:method:: __pos__()
+
+   :meta self-param: obj
+
+# binary operators (alphabetical)
+
+.. py:method:: __add__(other)
+
+   :meta self-param: obj
+
+.. py:method:: __and__(other)
+
+   :meta self-param: obj
+
+.. py:method:: __divmod__(other)
+
+   :meta self-param: obj
+
+.. py:method:: __eq__(other)
+
+   :meta self-param: obj
+
+.. py:method:: __floordiv__(other)
+
+   :meta self-param: obj
+
+.. py:method:: __ge__(other)
+
+   :meta self-param: obj
+
+.. py:method:: __gt__(other)
+
+   :meta self-param: obj
+
+.. py:method:: __le__(other)
+
+   :meta self-param: obj
+
+.. py:method:: __lshift__(other)
+
+   :meta self-param: obj
+
+.. py:method:: __lt__(other)
+
+   :meta self-param: obj
+
+.. py:method:: __matmul__(other)
+
+   :meta self-param: obj
+
+.. py:method:: __mod__(other)
+
+   :meta self-param: obj
+
+.. py:method:: __mul__(other)
+
+   :meta self-param: obj
+
+.. py:method:: __ne__(other)
+
+   :meta self-param: obj
+
+.. py:method:: __or__(other)
+
+   :meta self-param: obj
+
+.. py:method:: __pow__(other)
+
+   :meta self-param: obj
+
+.. py:method:: __rshift__(other)
+
+   :meta self-param: obj
+
+.. py:method:: __sub__(other)
+
+   :meta self-param: obj
+
+.. py:method:: __truediv__(other)
+
+   :meta self-param: obj
+
+.. py:method:: __xor__(other)
+
+   :meta self-param: obj
+
+# other math
+
+.. py:method:: __abs__()
+
+   :meta self-param: obj
+
+.. py:method:: __ceil__()
+
+   :meta self-param: obj
+
+.. py:method:: __floor__()
+
+   :meta self-param: obj
+
+.. py:method:: __round__(n)
+
+   :meta self-param: obj
+
+.. py:method:: __trunc__()
+
+   :meta self-param: obj

--- a/tests/test-simple/index.rst
+++ b/tests/test-simple/index.rst
@@ -1,4 +1,4 @@
-misc (alphabetical)
+# misc (alphabetical)
 
 .. py:method:: __await__()
 
@@ -14,7 +14,7 @@ misc (alphabetical)
 
 .. py:method:: __sizeof__()
 
-type coercion
+# type coercion
 
 .. py:method:: __str__()
 
@@ -30,7 +30,7 @@ type coercion
 
 .. py:method:: __index__()
 
-attribute access
+# attribute access
 
 .. py:method:: __getattr__(attr)
 
@@ -38,7 +38,7 @@ attribute access
 
 .. py:method:: __delattr__(attr)
 
-sequence methods
+# sequence methods
 
 .. py:method:: __contains__(value)
 
@@ -56,7 +56,7 @@ sequence methods
 
 .. py:method:: __reversed__()
 
-unary operators (alphabetical)
+# unary operators (alphabetical)
 
 .. py:method:: __invert__()
 
@@ -64,7 +64,7 @@ unary operators (alphabetical)
 
 .. py:method:: __pos__()
 
-binary operators (alphabetical)
+# binary operators (alphabetical)
 
 .. py:method:: __add__(other)
 
@@ -106,7 +106,7 @@ binary operators (alphabetical)
 
 .. py:method:: __xor__(other)
 
-other math
+# other math
 
 .. py:method:: __abs__()
 

--- a/tests/test_plaintext.py
+++ b/tests/test_plaintext.py
@@ -1,6 +1,78 @@
 import pytest
 
 
+# SIMPLE_RESULT is shared among all tests as a check to ensure that
+# all tests cover all supported special methods.
+# Do not switch to separate values for each test without
+# developing a replacement mechanism for ensuring this consistency.
+
+# Non-method lines in result are prefixed with a hash (#)
+# to allow for filtering
+
+SIMPLE_RESULT = [
+    '# misc (alphabetical)',
+    'await *self*',
+    '*self*(*args, **kwargs)',
+    'dir(self)',
+    'format(self, fmt)',
+    'hash(self)',
+    'repr(self)',
+    'sys.getsizeof(self)',
+    '# type coercion',
+    'str(self)',
+    'bytes(self)',
+    'bool(self)',
+    'int(self)',
+    'float(self)',
+    'complex(self)',
+    'operator.index(self)',
+    '# attribute access',
+    'getattr(self, attr)',
+    'setattr(self, attr, value)',
+    'delattr(self, attr)',
+    '# sequence methods',
+    '*value* in *self*',
+    '*self*[*item*]',
+    '*self*[*item*] = *value*',
+    'del *self*[*item*]',
+    'iter(self)',
+    'len(self)',
+    'operator.length_hint(self)',
+    'reversed(self)',
+    '# unary operators (alphabetical)',
+    '~*self*',
+    '-*self*',
+    '+*self*',
+    '# binary operators (alphabetical)',
+    '*self* + *other*',
+    '*self* & *other*',
+    'divmod(self, other)',
+    '*self* == *other*',
+    '*self* // *other*',
+    '*self* >= *other*',
+    '*self* > *other*',
+    '*self* <= *other*',
+    '*self* << *other*',
+    '*self* < *other*',
+    '*self* @ *other*',
+    '*self* % *other*',
+    '*self* * *other*',
+    '*self* != *other*',
+    '*self* | *other*',
+    '*self* ** *other*',
+    '*self* >> *other*',
+    '*self* - *other*',
+    '*self* / *other*',
+    '*self* ^ *other*',
+    '# other math',
+    'abs(self)',
+    'math.ceil(self)',
+    'math.floor(self)',
+    'round(self, n)',
+    'math.trunc(self)',
+]
+
+
 @pytest.mark.sphinx(testroot='simple', buildername='text')
 def test_domain_py_objects(app, status, warning):
     app.builder.build_all()
@@ -8,65 +80,17 @@ def test_domain_py_objects(app, status, warning):
 
     lines = [line.rstrip('\n') for line in result.splitlines() if line.strip()]
 
-    assert lines == [
-        'misc (alphabetical)',
-        'await *self*',
-        '*self*(*args, **kwargs)',
-        'dir(self)',
-        'format(self, fmt)',
-        'hash(self)',
-        'repr(self)',
-        'sys.getsizeof(self)',
-        'type coercion',
-        'str(self)',
-        'bytes(self)',
-        'bool(self)',
-        'int(self)',
-        'float(self)',
-        'complex(self)',
-        'operator.index(self)',
-        'attribute access',
-        'getattr(self, attr)',
-        'setattr(self, attr, value)',
-        'delattr(self, attr)',
-        'sequence methods',
-        '*value* in *self*',
-        '*self*[*item*]',
-        '*self*[*item*] = *value*',
-        'del *self*[*item*]',
-        'iter(self)',
-        'len(self)',
-        'operator.length_hint(self)',
-        'reversed(self)',
-        'unary operators (alphabetical)',
-        '~*self*',
-        '-*self*',
-        '+*self*',
-        'binary operators (alphabetical)',
-        '*self* + *other*',
-        '*self* & *other*',
-        'divmod(self, other)',
-        '*self* == *other*',
-        '*self* // *other*',
-        '*self* >= *other*',
-        '*self* > *other*',
-        '*self* <= *other*',
-        '*self* << *other*',
-        '*self* < *other*',
-        '*self* @ *other*',
-        '*self* % *other*',
-        '*self* * *other*',
-        '*self* != *other*',
-        '*self* | *other*',
-        '*self* ** *other*',
-        '*self* >> *other*',
-        '*self* - *other*',
-        '*self* / *other*',
-        '*self* ^ *other*',
-        'other math',
-        'abs(self)',
-        'math.ceil(self)',
-        'math.floor(self)',
-        'round(self, n)',
-        'math.trunc(self)',
-    ]
+    assert lines == SIMPLE_RESULT
+
+
+@pytest.mark.sphinx(testroot='autodoc', buildername='text')
+def test_autodoc_module(app, status, warning):
+    app.builder.build_all()
+    result = (app.outdir / 'index.txt').read_text()
+
+    lines = [line.strip() for line in result.splitlines() if line.strip()]
+
+    expected = [line for line in SIMPLE_RESULT if not line.startswith('#')]
+    expected.insert(0, 'class test_autodoc_module.MethodHolder')
+
+    assert lines == expected

--- a/tests/test_plaintext.py
+++ b/tests/test_plaintext.py
@@ -83,6 +83,16 @@ def test_domain_py_objects(app, status, warning):
     assert lines == SIMPLE_RESULT
 
 
+@pytest.mark.sphinx(testroot='simple-self-param', buildername='text')
+def test_domain_py_objects_with_self_param(app, status, warning):
+    app.builder.build_all()
+    result = (app.outdir / 'index.txt').read_text()
+
+    lines = [line.rstrip('\n') for line in result.splitlines() if line.strip()]
+
+    assert lines == [line.replace('self', 'obj') for line in SIMPLE_RESULT]
+
+
 @pytest.mark.sphinx(testroot='autodoc', buildername='text')
 def test_autodoc_module(app, status, warning):
     app.builder.build_all()
@@ -92,5 +102,22 @@ def test_autodoc_module(app, status, warning):
 
     expected = [line for line in SIMPLE_RESULT if not line.startswith('#')]
     expected.insert(0, 'class test_autodoc_module.MethodHolder')
+
+    assert lines == expected
+
+
+@pytest.mark.sphinx(testroot='autodoc-self-param', buildername='text')
+def test_autodoc_module_with_self_param(app, status, warning):
+    app.builder.build_all()
+    result = (app.outdir / 'index.txt').read_text()
+
+    lines = [line.strip() for line in result.splitlines() if line.strip()]
+
+    expected = [
+        line.replace('self', 'obj')
+        for line in SIMPLE_RESULT
+        if not line.startswith('#')
+    ]
+    expected.insert(0, 'class test_autodoc_self_param_module.MethodHolder')
 
     assert lines == expected


### PR DESCRIPTION
This set of changes implements a mechanism for specifying a replacement for "self" in the generated signatures (see #11). I had to make some fairly major changes to make this work, so please review them carefully. If there's better ways of solving any of these problems, I'll be happy to rework my changes.

The concerns I have:

1. I decided to call the appearance of "self" in the output "signature" a "self reference." I'm open to reworking this with better naming.
1. I chose to use a [`meta` info field](https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#info-field-lists) for specifying the new name. I chose this because I couldn't find any other simple way of providing an input value to the `py:method` domain directive; it seems to be effectively closed to extension. Is there a better approach to providing the name?
1. Because I used a `meta` info field, the existing transform was occurring much too late in the process of generating documentation. By the time it was invoked, `meta` info fields had been filtered out of the docstring. To solve this, I had to convert the transform into an event handler and specify its priority to invoke it before the meta filtering event. Is there a better way to make the transform happen early enough in the process?
1. The event I believed to be the most appropriate choice doesn't pass the method's full document node directly; it passes the docstring node, whose parent is the method's full node. This means I had to traverse one level above the node in the handler to replace the signature. Is doing so bad style, and can we avoid doing so?
1. I added several tests to ensure I didn't break anything and to test my new changes: an autodoc test, a test on explicit use of `py:method` with a `selfref` field, and a test on autodoc with a `selfref` field. One thing I don't like about this is that there are now four separate files listing all the methods this project covers. To try to ensure that they remain in sync as the project covers more special methods, I gave the tests a shared expected output (with some filtering to simplify the autodoc cases). Is there a better way to maintain or enforce consistency between all the files? We *could* generate them automatically somehow, but it would make the project more complex.