### PR TITLE
Make sure PBR gets the distribution (package) name

### DIFF
--- a/sphinxcontrib/prettyspecialmethods.py
+++ b/sphinxcontrib/prettyspecialmethods.py
@@ -19,7 +19,7 @@ if False:
     from sphinx.application import Sphinx  # noqa
 
 __version__ = pbr.version.VersionInfo(
-    'prettyspecialmethods').version_string()
+    'sphinxcontrib-prettyspecialmethods').version_string()
 
 
 def patch_node(node, text=None, children=None, *, constructor=None):


### PR DESCRIPTION
Ok, so the PyPI and import names for a given module can be wildly different, right?

Under some circumstances, I'm getting an error:

> Exception: Versioning for this project requires either an sdist tarball, or access to an upstream git repository. It's also possible that there is a mismatch between the package name in setup.cfg and the argument given to pbr.version.VersionInfo. Project name prettyspecialmethods was given, but was not able to be found.

`prettyspecialmethods` isn't a valid global name in any context, it's either `sphinxcontrib-prettyspecialmethods` (PyPI package) or `sphinxcontrib.prettyspecialmethods` (module import).

Looking at the full backtrace and some other usage examples, I think PBR is expecting the package name.

This is more guesswork than I generally like because I'm getting errors in my CI/CD but not when I try it locally and I have no idea what the difference is.

Full sphinx build log:

```
# Platform:         linux; (Linux-5.4.0-128-generic-x86_64-with-glibc2.31)
# Sphinx version:   6.1.3
# Python version:   3.11.2 (CPython)
# Docutils version: 0.19
# Jinja2 version:   3.1.2
# Pygments version: 2.14.0

# Last messages:


# Loaded extensions:


# Traceback:
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/importlib/metadata/__init__.py", line 563, in from_name
    return next(cls.discover(name=name))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
StopIteration

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/pbr/version.py", line 475, in _get_version_from_importlib_metadata
    distribution = importlib_metadata.distribution(self.package)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/importlib/metadata/__init__.py", line 981, in distribution
    return Distribution.from_name(distribution_name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/importlib/metadata/__init__.py", line 565, in from_name
    raise PackageNotFoundError(name)
importlib.metadata.PackageNotFoundError: No package metadata was found for prettyspecialmethods

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/sphinx/cmd/build.py", line 279, in build_main
    app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/sphinx/application.py", line 223, in __init__
    self.setup_extension(extension)
  File "/usr/local/lib/python3.11/site-packages/sphinx/application.py", line 398, in setup_extension
    self.registry.load_extension(self, extname)
  File "/usr/local/lib/python3.11/site-packages/sphinx/registry.py", line 443, in load_extension
    mod = import_module(extname)
          ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1206, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1149, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/usr/local/lib/python3.11/site-packages/sphinxcontrib/prettyspecialmethods.py", line 22, in <module>
    'prettyspecialmethods').version_string()
                            ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pbr/version.py", line 505, in version_string
    return self.semantic_version().brief_string()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pbr/version.py", line 498, in semantic_version
    self._semantic = self._get_version_from_importlib_metadata()
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pbr/version.py", line 482, in _get_version_from_importlib_metadata
    result_string = packaging.get_version(self.package)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pbr/packaging.py", line 874, in get_version
    raise Exception("Versioning for this project requires either an sdist"
Exception: Versioning for this project requires either an sdist tarball, or access to an upstream git repository. It's also possible that there is a mismatch between the package name in setup.cfg and the argument given to pbr.version.VersionInfo. Project name prettyspecialmethods was given, but was not able to be found.
```